### PR TITLE
Add docpad's layouts path to the swig root paths

### DIFF
--- a/out/swig.plugin.js
+++ b/out/swig.plugin.js
@@ -19,8 +19,13 @@
         inExtension = opts.inExtension, templateData = opts.templateData;
         if (inExtension === 'swig') {
           swig = require('swig');
-          swig.init({autoescape:false, root: opts.file.attributes.fullDirPath})
-          tpl = swig.compile(opts.content)
+
+          var root = this.docpad.config.layoutsPaths;
+          // Add the current file's path as well for locally relative swig file references
+          root.push(opts.file.attributes.fullDirPath);
+
+          swig.init({autoescape:false, root: root});
+          tpl = swig.compile(opts.content);
           return opts.content = tpl(templateData);
         }
       };


### PR DESCRIPTION
This fork adds docpad's layouts paths (`src/layouts/`) to the swig `root` config in addition to the current file's path.

This way it becomes possible to have a swig file like:

```
src/layouts/macros/main.html.swig
```

and reference it in a document file such as:

```
src/documents/subdir/somefile.html.swig
```

like this:

```
{% import 'macros/main.html.swig' as macros %}
```
