### PR TITLE
DocPad plugins use v2.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "docpad-plugin-swig",
-	"version": "0.0.3",
+	"version": "2.0.3",
 	"description": "Adds support for the swig templating engine to DocPad.",
 	"homepage": "http://github.com/thisispete/docpad-plugin-swig",
 	"keywords": [


### PR DESCRIPTION
Fixes #5 and https://github.com/docpad/docpad/issues/910 
See "package.json" on the "Write a Plugin" page [here](https://docpad.org/docs/plugin-write).
Cheers!  :smiley_cat: :beers: :panda_face:  
